### PR TITLE
Fixed directory handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,8 +39,9 @@ jobs:
           package_id: 'TestZipPackage'
           version: '1.0.0'
           output_folder: './packaging'
+          base_path: reports
           files: |
-            reports/**/*
+            **/*
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,4 +46,4 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: TestZipPackage.1.0.0
-          path: ${{ steps.self_test.outputs.package_file }}
+          path: ${{ steps.self_test.outputs.package_file_path }}

--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ steps:
 
 ## 📥 Inputs
 
-| Name            | Description                                                                          |
-| :-------------- | :----------------------------------------------------------------------------------- |
-| `package_id`    | **Required.** Package id.                                                            |
-| `version`       | **Required.** Package version.                                                       |
-| `output_folder` | **Required.** The folder to put the resulting package in.                            |
-| `files`         | **Required.** Multi-line list of files to include in the package. Supports globbing. |
+| Name            | Description                                                                                                     |
+| :-------------- | :-------------------------------------------------------------------------------------------------------------- |
+| `package_id`    | **Required.** Package id.                                                                                       |
+| `version`       | **Required.** Package version.                                                                                  |
+| `output_folder` | **Required.** The folder to put the resulting package in.                                                       |
+| `base_path`     | **Required.** The base path for the input files.                                                                |
+| `files`         | **Required.** Multi-line list of files to include in the package, relative to the base path. Supports globbing. |
 
 ## 📤 Outputs
 

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ steps:
 
 ## 📥 Inputs
 
-| Name            | Description                                                                                                     |
-| :-------------- | :-------------------------------------------------------------------------------------------------------------- |
-| `package_id`    | **Required.** Package id.                                                                                       |
-| `version`       | **Required.** Package version.                                                                                  |
-| `output_folder` | **Required.** The folder to put the resulting package in.                                                       |
-| `base_path`     | **Required.** The base path for the input files.                                                                |
-| `files`         | **Required.** Multi-line list of files to include in the package, relative to the base path. Supports globbing. |
+| Name            | Description                                                                                                             |
+| :-------------- | :---------------------------------------------------------------------------------------------------------------------- |
+| `package_id`    | **Required.** Package id.                                                                                               |
+| `version`       | **Required.** Package version.                                                                                          |
+| `output_folder` | **Required.** The folder to put the resulting package in, relative to the current working directory, not the base_path. |
+| `base_path`     | **Required.** The base path for the input files.                                                                        |
+| `files`         | **Required.** Multi-line list of files to include in the package, relative to the base path. Supports globbing.         |
 
 ## 📤 Outputs
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ steps:
 
 ## 📤 Outputs
 
-| Name           | Description                                         |
-| :------------- | :-------------------------------------------------- |
-| `package_file` | The full path to the package file that was created. |
+| Name                | Description                                                   |
+| :------------------ | :------------------------------------------------------------ |
+| `package_file_path` | The full path to the package file that was created.           |
+| `package_filename`  | The filename, without the path, of the file that was created. |
 
 ## 🤝 Contributions
 

--- a/__tests__/unit/input-parsing.test.ts
+++ b/__tests__/unit/input-parsing.test.ts
@@ -3,7 +3,11 @@ import { getInputParameters } from '../../src/input-parameters'
 test('get input parameters', () => {
   const inputParameters = getInputParameters()
   expect(inputParameters).toBeDefined()
+  expect(inputParameters.packageId).toEqual('testPackage')
+  expect(inputParameters.version).toEqual('1.0.0')
+  expect(inputParameters.outputFolder).toEqual('packaging')
+  expect(inputParameters.basePath).toEqual('published')
   expect(inputParameters.files).toBeDefined()
   expect(inputParameters.files).toHaveLength(1)
-  expect(inputParameters.files).toContain('published/**/*')
+  expect(inputParameters.files).toContain('**/*')
 })

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: 'Package version.'
     required: true
   output_folder:
-    description: 'Package Id.'
+    description: 'The folder to put the resulting package in, relative to the current working directory, not the base_path.'
     required: true
   base_path:
     description: 'The base path for the input files.'

--- a/action.yml
+++ b/action.yml
@@ -15,8 +15,11 @@ inputs:
   output_folder:
     description: 'Package Id.'
     required: true
+  base_path:
+    description: 'The base path for the input files.'
+    required: true
   files:
-    description: 'Multi-line list of files to include in the package. Supports globbing.'
+    description: 'Multi-line list of files to include in the package, relative to the basePath. Supports globbing.'
     required: true
 
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -23,8 +23,10 @@ inputs:
     required: true
 
 outputs:
-  package_file:
+  package_file_path:
     description: 'The full path to the package file that was created.'
+  package_filename:
+    description: 'The filename, without the path, of the file that was created.'
 
 runs:
   using: 'node16'

--- a/dist/index.js
+++ b/dist/index.js
@@ -3742,7 +3742,7 @@ function doZip(basePath, inputFilePatterns, outputFolder, zipFilename, logger, c
                             file = files_1_1.value;
                             (_b = logger.debug) === null || _b === void 0 ? void 0 : _b.call(logger, "Adding file: ".concat(file, "..."));
                             if (fs_1.default.lstatSync(file).isDirectory()) {
-                                zip.addFile("".concat(file, "/"), new Buffer([0x00]));
+                                zip.addFile("".concat(file, "/"), Buffer.from([0x00]));
                             }
                             else {
                                 dirName = path_1.default.dirname(file);
@@ -3762,7 +3762,7 @@ function doZip(basePath, inputFilePatterns, outputFolder, zipFilename, logger, c
                     }
                     setCompressionLevel(zip, compressionLevel || 8);
                     process.chdir(initialWorkingDirectory);
-                    return [4 /*yield*/, zip.writeZipPromise(archivePath, { overwrite: overwrite })];
+                    return [4 /*yield*/, zip.writeZipPromise(archivePath, { overwrite: overwrite || true })];
                 case 2:
                     _e.sent();
                     return [2 /*return*/];

--- a/dist/index.js
+++ b/dist/index.js
@@ -3706,6 +3706,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.doZip = void 0;
 var adm_zip_1 = __importDefault(__nccwpck_require__(6761));
+var fs_1 = __importDefault(__nccwpck_require__(7147));
 var glob_1 = __nccwpck_require__(1957);
 var path_1 = __importDefault(__nccwpck_require__(1017));
 var util_1 = __nccwpck_require__(3837);
@@ -3728,7 +3729,12 @@ function doZip(inputFilePatterns, outputFolder, zipFilename, logger, compression
                         for (files_1 = __values(files), files_1_1 = files_1.next(); !files_1_1.done; files_1_1 = files_1.next()) {
                             file = files_1_1.value;
                             (_b = logger.debug) === null || _b === void 0 ? void 0 : _b.call(logger, "Adding file: ".concat(file, "..."));
-                            zip.addLocalFile(file);
+                            if (fs_1.default.lstatSync(file).isDirectory()) {
+                                zip.addFile("".concat(file, "/"), new Buffer([0x00]));
+                            }
+                            else {
+                                zip.addLocalFile(file, path_1.default.dirname(file));
+                            }
                         }
                     }
                     catch (e_1_1) { e_1 = { error: e_1_1 }; }

--- a/dist/index.js
+++ b/dist/index.js
@@ -3523,22 +3523,21 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.NuGetPackageBuilder = void 0;
 var zipUtils_1 = __nccwpck_require__(7273);
 var fs_1 = __importDefault(__nccwpck_require__(7147));
-var os_1 = __importDefault(__nccwpck_require__(2037));
 var path_1 = __importDefault(__nccwpck_require__(1017));
 var NuGetPackageBuilder = /** @class */ (function () {
     function NuGetPackageBuilder() {
     }
     NuGetPackageBuilder.prototype.pack = function (args) {
         return __awaiter(this, void 0, void 0, function () {
-            var archiveFilename, tmpFolder, inputFilePatterns, nuspecFile;
+            var archiveFilename, inputFilePatterns, nuspecFilename, nuspecFile;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
                         archiveFilename = "".concat(args.packageId, ".").concat(args.version, ".nupkg");
-                        tmpFolder = os_1.default.tmpdir();
                         inputFilePatterns = args.inputFilePatterns;
                         if (args.nuspecArgs) {
-                            nuspecFile = path_1.default.join(tmpFolder, "".concat(args.packageId, ".nuspec"));
+                            nuspecFilename = "".concat(args.packageId, ".nuspec");
+                            nuspecFile = path_1.default.join(args.basePath, nuspecFilename);
                             fs_1.default.writeFileSync(nuspecFile, '<?xml version="1.0" encoding="utf-8"?>\n');
                             fs_1.default.appendFileSync(nuspecFile, '<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">\n');
                             fs_1.default.appendFileSync(nuspecFile, "    <metadata>\n");
@@ -3552,9 +3551,9 @@ var NuGetPackageBuilder = /** @class */ (function () {
                             fs_1.default.appendFileSync(nuspecFile, "    </metadata>\n");
                             fs_1.default.appendFileSync(nuspecFile, "</package>\n");
                             // include the nuspec into the package
-                            inputFilePatterns.push(nuspecFile);
+                            inputFilePatterns.push(nuspecFilename);
                         }
-                        return [4 /*yield*/, (0, zipUtils_1.doZip)(inputFilePatterns, args.outputFolder, archiveFilename, args.logger, 8, args.overwrite)];
+                        return [4 /*yield*/, (0, zipUtils_1.doZip)(args.basePath, inputFilePatterns, args.outputFolder, archiveFilename, args.logger, 8, args.overwrite)];
                     case 1:
                         _a.sent();
                         return [2 /*return*/, archiveFilename];
@@ -3633,7 +3632,7 @@ var ZipPackageBuilder = /** @class */ (function () {
                 switch (_a.label) {
                     case 0:
                         archiveFilename = "".concat(args.packageId, ".").concat(args.version, ".zip");
-                        return [4 /*yield*/, (0, zipUtils_1.doZip)(args.inputFilePatterns, args.outputFolder, archiveFilename, args.logger, args.compressionLevel, args.overwrite)];
+                        return [4 /*yield*/, (0, zipUtils_1.doZip)(args.basePath, args.inputFilePatterns, args.outputFolder, archiveFilename, args.logger, args.compressionLevel, args.overwrite)];
                     case 1:
                         _a.sent();
                         return [2 /*return*/, archiveFilename];
@@ -3711,16 +3710,29 @@ var glob_1 = __nccwpck_require__(1957);
 var path_1 = __importDefault(__nccwpck_require__(1017));
 var util_1 = __nccwpck_require__(3837);
 var globp = (0, util_1.promisify)(glob_1.glob);
-function doZip(inputFilePatterns, outputFolder, zipFilename, logger, compressionLevel, overwrite) {
+/**
+ * Creates a Zip file with a given filename from the inputFilePatterns.
+ *
+ * @param {string} basePath The base path for the input files.
+ * @param {string[]} inputFilePatterns Array of input file patterns, relative to the basePath. Specific files and globbing patterns are both supported.
+ * @param {string} outputFolder The folder to write the resulting Zip file to.
+ * @param {string} zipFilename The name of the Zip file to create.
+ * @param {Logger} logger Logger implementation for writing debug and info messages
+ * @param {number} compressionLevel Optional override for the compression level. Defaults to 8 if not specified.
+ * @param {boolean} overwrite Whether to overwrite the Zip file if it already exists. Defaults to true if not specified.
+ */
+function doZip(basePath, inputFilePatterns, outputFolder, zipFilename, logger, compressionLevel, overwrite) {
     var _a, _b, _c;
     return __awaiter(this, void 0, void 0, function () {
-        var archivePath, zip, files, files_1, files_1_1, file;
+        var archivePath, initialWorkingDirectory, zip, files, files_1, files_1_1, file, dirName;
         var e_1, _d;
         return __generator(this, function (_e) {
             switch (_e.label) {
                 case 0:
                     archivePath = path_1.default.resolve(outputFolder, zipFilename);
                     (_a = logger.info) === null || _a === void 0 ? void 0 : _a.call(logger, "Writing to package: ".concat(archivePath, "..."));
+                    initialWorkingDirectory = process.cwd();
+                    process.chdir(path_1.default.resolve(initialWorkingDirectory, basePath));
                     zip = new adm_zip_1.default();
                     return [4 /*yield*/, expandGlobs(inputFilePatterns)];
                 case 1:
@@ -3733,7 +3745,8 @@ function doZip(inputFilePatterns, outputFolder, zipFilename, logger, compression
                                 zip.addFile("".concat(file, "/"), new Buffer([0x00]));
                             }
                             else {
-                                zip.addLocalFile(file, path_1.default.dirname(file));
+                                dirName = path_1.default.dirname(file);
+                                zip.addLocalFile(file, dirName === "." ? "" : dirName);
                             }
                         }
                     }
@@ -3748,6 +3761,7 @@ function doZip(inputFilePatterns, outputFolder, zipFilename, logger, compression
                         (_c = logger.info) === null || _c === void 0 ? void 0 : _c.call(logger, "Overriding compression level: ".concat(compressionLevel));
                     }
                     setCompressionLevel(zip, compressionLevel || 8);
+                    process.chdir(initialWorkingDirectory);
                     return [4 /*yield*/, zip.writeZipPromise(archivePath, { overwrite: overwrite })];
                 case 2:
                     _e.sent();
@@ -41531,6 +41545,7 @@ function createPackageFromInputs(parameters, logger) {
             packageId: parameters.packageId,
             version: parameters.version,
             outputFolder: parameters.outputFolder,
+            basePath: parameters.basePath,
             inputFilePatterns: parameters.files,
             overwrite: true,
             logger
@@ -41615,6 +41630,7 @@ function getInputParameters() {
         packageId: (0, core_1.getInput)('package_id', { required: true }),
         version: (0, core_1.getInput)('version', { required: true }),
         outputFolder: (0, core_1.getInput)('output_folder', { required: true }),
+        basePath: (0, core_1.getInput)('base_path', { required: true }),
         files: (0, core_1.getMultilineInput)('files', { required: true })
     };
     return parameters;

--- a/dist/index.js
+++ b/dist/index.js
@@ -41550,7 +41550,7 @@ function createPackageFromInputs(parameters, logger) {
             overwrite: true,
             logger
         });
-        return path_1.default.join(parameters.outputFolder, packageFilename);
+        return { filePath: path_1.default.join(parameters.outputFolder, packageFilename), filename: packageFilename };
     });
 }
 exports.createPackageFromInputs = createPackageFromInputs;
@@ -41597,11 +41597,12 @@ const fs_1 = __nccwpck_require__(7147);
             }
         };
         const parameters = (0, input_parameters_1.getInputParameters)();
-        const packageFile = yield (0, create_package_1.createPackageFromInputs)(parameters, logger);
-        (0, core_1.setOutput)('package_file', packageFile);
+        const result = yield (0, create_package_1.createPackageFromInputs)(parameters, logger);
+        (0, core_1.setOutput)('package_file_path', result.filePath);
+        (0, core_1.setOutput)('package_filename', result.filename);
         const stepSummaryFile = process.env.GITHUB_STEP_SUMMARY;
         if (stepSummaryFile) {
-            (0, fs_1.writeFileSync)(stepSummaryFile, `🐙 Created package ${packageFile}`);
+            (0, fs_1.writeFileSync)(stepSummaryFile, `🐙 Created package ${result.filename}`);
         }
     }
     catch (e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.10.0",
-        "@octopusdeploy/api-client": "^2.1.0",
+        "@octopusdeploy/api-client": "github:OctopusDeploy/api-client.ts#bug-directoryhandling",
         "glob": "^8.0.3"
       },
       "devDependencies": {
@@ -1241,8 +1241,8 @@
     },
     "node_modules/@octopusdeploy/api-client": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@octopusdeploy/api-client/-/api-client-2.1.0.tgz",
-      "integrity": "sha512-6qabUJzMPMpkoCxS/j1AmTZS8sRXJk2ep+8d/axslGywxNAkYGLVxCkfAr3n93KvALGWn6oPjUk79wv/46trVw==",
+      "resolved": "git+ssh://git@github.com/OctopusDeploy/api-client.ts.git#f3bf14747723ad806133e473abc58315f10660e2",
+      "license": "Apache-2.0",
       "dependencies": {
         "adm-zip": "^0.5.9",
         "axios": "^0.27.2",
@@ -7093,9 +7093,8 @@
       }
     },
     "@octopusdeploy/api-client": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@octopusdeploy/api-client/-/api-client-2.1.0.tgz",
-      "integrity": "sha512-6qabUJzMPMpkoCxS/j1AmTZS8sRXJk2ep+8d/axslGywxNAkYGLVxCkfAr3n93KvALGWn6oPjUk79wv/46trVw==",
+      "version": "git+ssh://git@github.com/OctopusDeploy/api-client.ts.git#f3bf14747723ad806133e473abc58315f10660e2",
+      "from": "@octopusdeploy/api-client@github:OctopusDeploy/api-client.ts#bug-directoryhandling",
       "requires": {
         "adm-zip": "^0.5.9",
         "axios": "^0.27.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1241,7 +1241,7 @@
     },
     "node_modules/@octopusdeploy/api-client": {
       "version": "2.1.0",
-      "resolved": "git+ssh://git@github.com/OctopusDeploy/api-client.ts.git#f3bf14747723ad806133e473abc58315f10660e2",
+      "resolved": "git+ssh://git@github.com/OctopusDeploy/api-client.ts.git#8437177cd1ebaa4211d9d167b0503f173394c3a1",
       "license": "Apache-2.0",
       "dependencies": {
         "adm-zip": "^0.5.9",
@@ -7093,7 +7093,7 @@
       }
     },
     "@octopusdeploy/api-client": {
-      "version": "git+ssh://git@github.com/OctopusDeploy/api-client.ts.git#f3bf14747723ad806133e473abc58315f10660e2",
+      "version": "git+ssh://git@github.com/OctopusDeploy/api-client.ts.git#8437177cd1ebaa4211d9d167b0503f173394c3a1",
       "from": "@octopusdeploy/api-client@github:OctopusDeploy/api-client.ts#bug-directoryhandling",
       "requires": {
         "adm-zip": "^0.5.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1241,7 +1241,7 @@
     },
     "node_modules/@octopusdeploy/api-client": {
       "version": "2.1.0",
-      "resolved": "git+ssh://git@github.com/OctopusDeploy/api-client.ts.git#8437177cd1ebaa4211d9d167b0503f173394c3a1",
+      "resolved": "git+ssh://git@github.com/OctopusDeploy/api-client.ts.git#155d62964ba4a2aeba4cd7fa118738cba53af1df",
       "license": "Apache-2.0",
       "dependencies": {
         "adm-zip": "^0.5.9",
@@ -7093,7 +7093,7 @@
       }
     },
     "@octopusdeploy/api-client": {
-      "version": "git+ssh://git@github.com/OctopusDeploy/api-client.ts.git#8437177cd1ebaa4211d9d167b0503f173394c3a1",
+      "version": "git+ssh://git@github.com/OctopusDeploy/api-client.ts.git#155d62964ba4a2aeba4cd7fa118738cba53af1df",
       "from": "@octopusdeploy/api-client@github:OctopusDeploy/api-client.ts#bug-directoryhandling",
       "requires": {
         "adm-zip": "^0.5.9",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "dependencies": {
     "@actions/core": "^1.10.0",
-    "@octopusdeploy/api-client": "^2.1.0",
+    "@octopusdeploy/api-client": "github:OctopusDeploy/api-client.ts#bug-directoryhandling",
     "glob": "^8.0.3"
   },
   "description": "GitHub Action to Push a Package to Octopus Deploy",

--- a/src/create-package.ts
+++ b/src/create-package.ts
@@ -2,7 +2,15 @@ import { Logger, ZipPackageBuilder } from '@octopusdeploy/api-client'
 import path from 'path'
 import { InputParameters } from './input-parameters'
 
-export async function createPackageFromInputs(parameters: InputParameters, logger: Logger): Promise<string> {
+type createPackageResult = {
+  filePath: string
+  filename: string
+}
+
+export async function createPackageFromInputs(
+  parameters: InputParameters,
+  logger: Logger
+): Promise<createPackageResult> {
   const builder = new ZipPackageBuilder()
   const packageFilename = await builder.pack({
     packageId: parameters.packageId,
@@ -14,5 +22,5 @@ export async function createPackageFromInputs(parameters: InputParameters, logge
     logger
   })
 
-  return path.join(parameters.outputFolder, packageFilename)
+  return { filePath: path.join(parameters.outputFolder, packageFilename), filename: packageFilename }
 }

--- a/src/create-package.ts
+++ b/src/create-package.ts
@@ -8,6 +8,7 @@ export async function createPackageFromInputs(parameters: InputParameters, logge
     packageId: parameters.packageId,
     version: parameters.version,
     outputFolder: parameters.outputFolder,
+    basePath: parameters.basePath,
     inputFilePatterns: parameters.files,
     overwrite: true,
     logger

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import { debug, error, info, isDebug, setFailed, setOutput, warning } from '@actions/core'
-import { getInputParameters } from './input-parameters'
-import { createPackageFromInputs } from './create-package'
 import { Logger } from '@octopusdeploy/api-client'
 import { writeFileSync } from 'fs'
+import { createPackageFromInputs } from './create-package'
+import { getInputParameters } from './input-parameters'
 
 // GitHub actions entrypoint
 ;(async (): Promise<void> => {
@@ -33,7 +33,7 @@ import { writeFileSync } from 'fs'
 
     const stepSummaryFile = process.env.GITHUB_STEP_SUMMARY
     if (stepSummaryFile) {
-      writeFileSync(stepSummaryFile, `🐙 Created package ${result.filename}`)
+      writeFileSync(stepSummaryFile, `🐙 Created package, ${result.filename}`)
     }
   } catch (e: unknown) {
     if (e instanceof Error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,13 +26,14 @@ import { writeFileSync } from 'fs'
 
     const parameters = getInputParameters()
 
-    const packageFile = await createPackageFromInputs(parameters, logger)
+    const result = await createPackageFromInputs(parameters, logger)
 
-    setOutput('package_file', packageFile)
+    setOutput('package_file_path', result.filePath)
+    setOutput('package_filename', result.filename)
 
     const stepSummaryFile = process.env.GITHUB_STEP_SUMMARY
     if (stepSummaryFile) {
-      writeFileSync(stepSummaryFile, `🐙 Created package ${packageFile}`)
+      writeFileSync(stepSummaryFile, `🐙 Created package ${result.filename}`)
     }
   } catch (e: unknown) {
     if (e instanceof Error) {

--- a/src/input-parameters.ts
+++ b/src/input-parameters.ts
@@ -4,6 +4,7 @@ export interface InputParameters {
   packageId: string
   version: string
   outputFolder: string
+  basePath: string
   files: string[]
 }
 
@@ -12,6 +13,7 @@ export function getInputParameters(): InputParameters {
     packageId: getInput('package_id', { required: true }),
     version: getInput('version', { required: true }),
     outputFolder: getInput('output_folder', { required: true }),
+    basePath: getInput('base_path', { required: true }),
     files: getMultilineInput('files', { required: true })
   }
 

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -6,7 +6,8 @@ process.env = Object.assign(process.env, {
   INPUT_PACKAGE_ID: 'testPackage',
   INPUT_VERSION: '1.0.0',
   INPUT_OUTPUT_FOLDER: 'packaging',
-  INPUT_FILES: 'published/**/*',
+  INPUT_BASE_PATH: 'published',
+  INPUT_FILES: '**/*',
   RUNNER_TEMP: tmpdir.name,
   RUNNER_TOOL_CACHE: tmpdir.name,
   GITHUB_ACTION: '1'


### PR DESCRIPTION
Updated the API client library to fix some directory handling issues.

This brings with it the introduction of a `basePath` input parameter. The `files` are then relative to that folder, given proper control of the package content structure.

Outputs have been changed to include both the full path to the resulting package, and also it's filename. This makes the upload step in GitHub Action much neater. You can do this

```
    - uses: actions/upload-artifact@v3
      with:
        name: ${{ steps.package.outputs.package_filename }}
        path: ${{ steps.package.outputs.package_file_path }}
```

Depends on OctopusDeploy/api-client.ts#130