### PR TITLE
chore: Update to `actions/upload-artifact` v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
           files: |
             **/*
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: TestZipPackage.1.0.0
           path: ${{ steps.self_test.outputs.package_file_path }}


### PR DESCRIPTION
[V3 of artifact actions are being deprecated on Nov 30th 2024](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) after which time workflows will fail. This PR updates to use v4.